### PR TITLE
useSelector: Allow optional compararison function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5010,8 +5010,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",

--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -14,6 +14,8 @@ import Subscription from '../utils/Subscription'
 const useIsomorphicLayoutEffect =
   typeof window !== 'undefined' ? useLayoutEffect : useEffect
 
+const refEquality = (a, b) => a === b
+
 /**
  * A hook to access the redux store's state. This hook takes a selector function
  * as an argument. The selector is called with the store state.
@@ -23,6 +25,7 @@ const useIsomorphicLayoutEffect =
  * useful if you provide a selector that memoizes values).
  *
  * @param {Function} selector the selector function
+ * @param {Function} equalityFn the function that will be used to determine equality
  *
  * @returns {any} the selected state
  *
@@ -37,7 +40,7 @@ const useIsomorphicLayoutEffect =
  *   return <div>{counter}</div>
  * }
  */
-export function useSelector(selector) {
+export function useSelector(selector, equalityFn = refEquality) {
   invariant(selector, `You must pass a selector to useSelectors`)
 
   const { store, subscription: contextSub } = useReduxContext()
@@ -82,7 +85,7 @@ export function useSelector(selector) {
       try {
         const newSelectedState = latestSelector.current(store.getState())
 
-        if (newSelectedState === latestSelectedState.current) {
+        if (equalityFn(newSelectedState, latestSelectedState.current)) {
           return
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import { useStore } from './hooks/useStore'
 
 import { setBatch } from './utils/batch'
 import { unstable_batchedUpdates as batch } from './utils/reactBatchedUpdates'
+import shallowEqual from './utils/shallowEqual'
 
 setBatch(batch)
 
@@ -20,5 +21,6 @@ export {
   batch,
   useDispatch,
   useSelector,
-  useStore
+  useStore,
+  shallowEqual
 }


### PR DESCRIPTION
I would like to add this commit to the PR so that it has [this suggestion](https://github.com/reduxjs/react-redux/pull/1288#issuecomment-493715499) from @markerikson

Thanks!

Changes:
- useSelector: Allow optional compararison function
- Export shallowEqual function